### PR TITLE
fix tkz-sty/tkz-euclide#2

### DIFF
--- a/latex/tkz-obj-eu-angles.tex
+++ b/latex/tkz-obj-eu-angles.tex
@@ -77,7 +77,7 @@
       mkcolor/.store in       = \tkz@mkcolor,
       arc                     = l,
       size                    = 1 cm,
-      mark                    = |,
+      mark                    = none,
       mksize                  = 4pt,
       mkcolor                 = black,
       mkpos                   = 0.5,


### PR DESCRIPTION
fix the difference between doc and default mark in \tkzMarkAngle (issue #2)